### PR TITLE
NEW: add FAIRagro NFDI

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,11 +6,12 @@
 * [NFDI4Cat](https://github.com/nfdi4cat)
 * [NFDI4Chem](https://github.com/NFDI4Chem)
 * [NFDI4Culture](https://github.com/NFDI4Culture)
-* [GHGA](https://github.com/ghga-de) 
+* [GHGA](https://github.com/ghga-de)
 * [NFDI4Health](https://github.com/NFDI4health)
 * [NFDI4Microbiota](https://github.com/NFDI4Microbiota/)
   * [The NFDI4Microbiota Knowledge Base](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base)
 * [NFDI4Plants](https://github.com/nfdi4plants)
+* [FAIRagro](https://github.com/fairagro)
 
 ### see also
-* [NFDI on GitLab](https://gitlab.com/nfdi-de/nfdi-de/-/blob/main/README.md) 
+* [NFDI on GitLab](https://gitlab.com/nfdi-de/nfdi-de/-/blob/main/README.md)


### PR DESCRIPTION
Add the FAIRagro NFDI to the list of NFDIs on GitHub (see https://fairagro.net/ and https://github.com/fairagro).