### PR TITLE
No subtopics in consortium list

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,7 +9,6 @@
 * [GHGA](https://github.com/ghga-de)
 * [NFDI4Health](https://github.com/NFDI4health)
 * [NFDI4Microbiota](https://github.com/NFDI4Microbiota/)
-  * [The NFDI4Microbiota Knowledge Base](https://github.com/NFDI4Microbiota/nfdi4microbiota-knowledge-base)
 * [NFDI4Plants](https://github.com/nfdi4plants)
 * [MaRDI4NFDI](https://github.com/MaRDI4NFDI)
 * [NFDI4DataScience](https://github.com/NFDI4DS)


### PR DESCRIPTION
Removed the link to 'The NFDI4Microbiota Knowledge Base' from the README.

Motivation: No subtopics for any consortium. - I was asked to add something for us but the page gets unusable if every consortium adds subtopics.